### PR TITLE
Add: filesystem=xdg-documents

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -15,6 +15,7 @@ finish-args:
   - --allow=devel
   - --system-talk-name=org.freedesktop.UDisks2
   - --system-talk-name=org.freedesktop.NetworkManager
+  - --filesystem=xdg-documents
   - --env=WINEDLLPATH=/app/dxvk/lib32:/app/dxvk/lib:/app/lib32/wine/wined3d:/app/lib/wine/wined3d
   - --env=WINEPREFIX=/var/data/wine
 command: wine


### PR DESCRIPTION
Many Windows games store save files in Documents dir. Without this permission they will all be lost.